### PR TITLE
Add filter fulfillment order line items example code

### DIFF
--- a/run-code-examples/fulfillment-order-filter-line-items/index.js
+++ b/run-code-examples/fulfillment-order-filter-line-items/index.js
@@ -1,0 +1,34 @@
+// This function filters fulfillmentOrderLine items if the product has a specific tag
+// This function can be updated to filter based on a different condition or parameter
+function shouldSplitLineItem(orderLineItems, fulfillmentOrderLineItem) {
+   return orderLineItems.some(lineItem => {
+    return lineItem.variant.product.title === fulfillmentOrderLineItem.productTitle && lineItem.variant.product.tags.includes("Refrigerated");
+  });
+}
+
+export default function main(input) {
+  const fulfillmentOrder = input.fulfillmentOrder
+  const orderLineItems = input.fulfillmentOrder.order.lineItems
+  const fulfillmentOrderSplitLineItems = []
+  const fulfillmentOrderSplits = []
+
+  fulfillmentOrder.lineItems.forEach(fulfillmentOrderLineItem => {
+    if (shouldSplitLineItem(orderLineItems, fulfillmentOrderLineItem)) {
+      fulfillmentOrderSplitLineItems.push({
+        "id": fulfillmentOrderLineItem.id,
+        "quantity": fulfillmentOrderLineItem.totalQuantity
+      })
+    }
+  });
+
+  if (fulfillmentOrderSplitLineItems.length >= 0) {
+    fulfillmentOrderSplits.push({
+      "fulfillmentOrderId": fulfillmentOrder.id,
+      "fulfillmentOrderLineItems": fulfillmentOrderSplitLineItems,
+    })
+  }
+
+  return {
+    fulfillmentOrderSplits: JSON.stringify(fulfillmentOrderSplits),
+  }
+}

--- a/run-code-examples/fulfillment-order-filter-line-items/input.graphql
+++ b/run-code-examples/fulfillment-order-filter-line-items/input.graphql
@@ -1,0 +1,20 @@
+query{
+  fulfillmentOrder {
+    id
+    lineItems {
+      id
+      totalQuantity
+      productTitle
+    }
+    order{
+      lineItems {
+        variant {
+          product {
+            title
+            tags
+          }
+        }
+      }
+    }
+  }
+}

--- a/run-code-examples/fulfillment-order-filter-line-items/output.graphql
+++ b/run-code-examples/fulfillment-order-filter-line-items/output.graphql
@@ -1,0 +1,4 @@
+type Output {
+  "The filtered fulfillment order line items"
+  fulfillmentOrderSplits: String!
+}

--- a/run-code-examples/fulfillment-order-filter-line-items/tests/example.test.js
+++ b/run-code-examples/fulfillment-order-filter-line-items/tests/example.test.js
@@ -1,0 +1,254 @@
+import main from "../index";
+
+describe("main", () => {
+  it("filters fulfillment order line items based on product tags", () => {
+    const input = {
+      fulfillmentOrder: {
+        id: "gid://shopify/FulfillmentOrder/1",
+        lineItems: [
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/1",
+            "totalQuantity": 1,
+            "productTitle": "Dry Product"
+          },
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/2",
+            "totalQuantity": 1,
+            "productTitle": "Refrigerated Product"
+          }
+        ],
+        order: {
+          lineItems: [
+          {
+            "variant": {
+              "product": {
+                "title": "Dry Product",
+                "tags": [
+                  "Dry"
+                ]
+              }
+            }
+          },
+          {
+            "variant": {
+              "product": {
+                "title": "Refrigerated Product",
+                "tags": [
+                  "Refrigerated"
+                ]
+              }
+            }
+          }
+          ]
+        }
+      }
+    };
+
+    const expectedOutput = {
+      fulfillmentOrderSplits: "[{\"fulfillmentOrderId\":\"gid://shopify/FulfillmentOrder/1\",\"fulfillmentOrderLineItems\":[{\"id\":\"gid://shopify/FulfillmentOrderLineItem/2\",\"quantity\":1}]}]",
+    };
+
+    const result = main(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("filters fulfillment order line items when multiple products have the specified tag", () => {
+    const input = {
+      fulfillmentOrder: {
+        id: "gid://shopify/FulfillmentOrder/1",
+        lineItems: [
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/1",
+            "totalQuantity": 1,
+            "productTitle": "Refrigerated Product 1"
+          },
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/2",
+            "totalQuantity": 1,
+            "productTitle": "Refrigerated Product 2"
+          }
+        ],
+        order: {
+          lineItems: [
+          {
+            "variant": {
+              "product": {
+                "title": "Refrigerated Product 1",
+                "tags": [
+                  "Refrigerated"
+                ]
+              }
+            }
+          },
+          {
+            "variant": {
+              "product": {
+                "title": "Refrigerated Product 2",
+                "tags": [
+                  "Refrigerated"
+                ]
+              }
+            }
+          }
+          ]
+        }
+      }
+    };
+
+    const expectedOutput = {
+      fulfillmentOrderSplits: "[{\"fulfillmentOrderId\":\"gid://shopify/FulfillmentOrder/1\",\"fulfillmentOrderLineItems\":[{\"id\":\"gid://shopify/FulfillmentOrderLineItem/1\",\"quantity\":1},{\"id\":\"gid://shopify/FulfillmentOrderLineItem/2\",\"quantity\":1}]}]",
+    };
+
+    const result = main(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("filters fulfillment order line items based on product tags when more then one tag is present", () => {
+    const input = {
+      fulfillmentOrder: {
+        id: "gid://shopify/FulfillmentOrder/1",
+        lineItems: [
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/1",
+            "totalQuantity": 1,
+            "productTitle": "Dry Product"
+          },
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/2",
+            "totalQuantity": 1,
+            "productTitle": "Refrigerated Product"
+          }
+        ],
+        order: {
+          lineItems: [
+          {
+            "variant": {
+              "product": {
+                "title": "Dry Product",
+                "tags": [
+                  "Dry",
+                  "Automated"
+                ]
+              }
+            }
+          },
+          {
+            "variant": {
+              "product": {
+                "title": "Refrigerated Product",
+                "tags": [
+                  "Refrigerated",
+                  "Automated"
+                ]
+              }
+            }
+          }
+          ]
+        }
+      }
+    };
+
+    const expectedOutput = {
+      fulfillmentOrderSplits: "[{\"fulfillmentOrderId\":\"gid://shopify/FulfillmentOrder/1\",\"fulfillmentOrderLineItems\":[{\"id\":\"gid://shopify/FulfillmentOrderLineItem/2\",\"quantity\":1}]}]",
+    };
+
+    const result = main(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("filters returns empty fulfillmentOrderLineItems array when no products match the specified tags", () => {
+    const input = {
+      fulfillmentOrder: {
+        id: "gid://shopify/FulfillmentOrder/1",
+        lineItems: [
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/1",
+            "totalQuantity": 1,
+            "productTitle": "Dry Product 1"
+          },
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/2",
+            "totalQuantity": 1,
+            "productTitle": "Dry Product 2"
+          }
+        ],
+        order: {
+          lineItems: [
+          {
+            "variant": {
+              "product": {
+                "title": "Dry Product 1",
+                "tags": [
+                  "Dry"
+                ]
+              }
+            }
+          },
+          {
+            "variant": {
+              "product": {
+                "title": "Dry Product 2",
+                "tags": []
+              }
+            }
+          }
+          ]
+        }
+      }
+    };
+
+    const expectedOutput = {
+      fulfillmentOrderSplits: "[{\"fulfillmentOrderId\":\"gid://shopify/FulfillmentOrder/1\",\"fulfillmentOrderLineItems\":[]}]",
+    };
+
+    const result = main(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("filters returns empty fulfillmentOrderLineItems array when no product tags are present", () => {
+    const input = {
+      fulfillmentOrder: {
+        id: "gid://shopify/FulfillmentOrder/1",
+        lineItems: [
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/1",
+            "totalQuantity": 1,
+            "productTitle": "Dry Product"
+          },
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/2",
+            "totalQuantity": 1,
+            "productTitle": "Refrigerated Product"
+          }
+        ],
+        order: {
+          lineItems: [
+          {
+            "variant": {
+              "product": {
+                "title": "Dry Product",
+                "tags": []
+              }
+            }
+          },
+          {
+            "variant": {
+              "product": {
+                "title": "Refrigerated Product",
+                "tags": []
+              }
+            }
+          }
+          ]
+        }
+      }
+    };
+
+    const expectedOutput = {
+      fulfillmentOrderSplits: "[{\"fulfillmentOrderId\":\"gid://shopify/FulfillmentOrder/1\",\"fulfillmentOrderLineItems\":[]}]",
+    };
+
+    const result = main(input);
+    expect(result).toEqual(expectedOutput);
+  });
+});


### PR DESCRIPTION
## Overview

Resolves https://github.com/Shopify/core-issues/issues/66261

## Discussion

The following code sample is built to demonstrate filtering and splitting fulfillment orders. It can be used in a workflow such as the one shown below:

![image](https://github.com/Shopify/flow-code-examples/assets/14330645/b39a6441-a9ca-49af-9ced-ef84200a83d1)

## Testing

Tophatted in production using the workflow shown above

All tests pass
<img width="747" alt="image" src="https://github.com/Shopify/flow-code-examples/assets/14330645/d1ac9b9b-82b5-4042-a32d-121c96a1a3a9">

