### PR TITLE
new(usr): Add example checking day of the week

### DIFF
--- a/run-code-examples/schedule-check-scheduled-day/index.js
+++ b/run-code-examples/schedule-check-scheduled-day/index.js
@@ -1,0 +1,12 @@
+/**
+ * Checks the current workflow is scheduled to run during the weekend (using Shop's timezone)
+*/
+export default function main(input) {
+  let scheduledAt = new Date(input.scheduledAt);
+  //convert to shop's time
+  scheduledAt = new Date(scheduledAt.setMinutes(scheduledAt.getMinutes() + input.shop.timezoneOffsetMinutes));
+  const dayOfWeek = scheduledAt.getDay();
+  return {
+    isWeekend: (dayOfWeek === 6) || (dayOfWeek  === 0),
+  };
+}

--- a/run-code-examples/schedule-check-scheduled-day/index.js
+++ b/run-code-examples/schedule-check-scheduled-day/index.js
@@ -1,5 +1,5 @@
 /**
- * Checks the current workflow is scheduled to run during the weekend (using Shop's timezone)
+ * Checks if the current workflow run is scheduled to run on a business day (using the Shop's timezone)
 */
 export default function main(input) {
   let scheduledAt = new Date(input.scheduledAt);
@@ -7,6 +7,6 @@ export default function main(input) {
   scheduledAt = new Date(scheduledAt.setMinutes(scheduledAt.getMinutes() + input.shop.timezoneOffsetMinutes));
   const dayOfWeek = scheduledAt.getDay();
   return {
-    isWeekend: (dayOfWeek === 6) || (dayOfWeek  === 0),
+    isBusinessDay: !((dayOfWeek === 6) || (dayOfWeek  === 0)),
   };
 }

--- a/run-code-examples/schedule-check-scheduled-day/input.graphql
+++ b/run-code-examples/schedule-check-scheduled-day/input.graphql
@@ -1,0 +1,6 @@
+query {
+  scheduledAt
+  shop {
+    timezoneOffsetMinutes
+  }
+}

--- a/run-code-examples/schedule-check-scheduled-day/output.graphql
+++ b/run-code-examples/schedule-check-scheduled-day/output.graphql
@@ -1,6 +1,6 @@
 "Output object"
 type Output {
-  "Whether the current day is in the weekend"
-  isWeekend: Boolean!
+  "Whether the current day is a business day"
+  isBusinessDay: Boolean!
 }
 

--- a/run-code-examples/schedule-check-scheduled-day/output.graphql
+++ b/run-code-examples/schedule-check-scheduled-day/output.graphql
@@ -1,0 +1,6 @@
+"Output object"
+type Output {
+  "Whether the current day is in the weekend"
+  isWeekend: Boolean!
+}
+

--- a/run-code-examples/schedule-check-scheduled-day/tests/check-scheduled-day.test.js
+++ b/run-code-examples/schedule-check-scheduled-day/tests/check-scheduled-day.test.js
@@ -3,14 +3,24 @@ import main from "../index";
 describe("main", () => {
   [
     {
-      name: "is false for business days",
+      name: "is true for business days",
       scheduledAt: "2024-02-22T14:32:00Z",
+      expected: true
+    },
+    {
+      name: "is true for business days",
+      scheduledAt: "2024-02-19T11:32:00Z",
+      expected: true
+    },
+    {
+      name: "is false for business days on weekend in shop's timezone",
+      scheduledAt: "2024-02-19T04:32:00Z",
       expected: false
     },
     {
-      name: "is true for weekends",
+      name: "is false for weekends",
       scheduledAt: "2024-02-24T23:32:00Z",
-      expected: true
+      expected: false
     },
   ].forEach(({name, scheduledAt, expected}) => {
     it(name, () => {
@@ -22,7 +32,7 @@ describe("main", () => {
       };
 
       const expectedOutput = {
-        isWeekend: expected,
+        isBusinessDay: expected,
       };
 
       const result = main(input);

--- a/run-code-examples/schedule-check-scheduled-day/tests/check-scheduled-day.test.js
+++ b/run-code-examples/schedule-check-scheduled-day/tests/check-scheduled-day.test.js
@@ -1,0 +1,32 @@
+import main from "../index";
+
+describe("main", () => {
+  [
+    {
+      name: "is false for business days",
+      scheduledAt: "2024-02-22T14:32:00Z",
+      expected: false
+    },
+    {
+      name: "is true for weekends",
+      scheduledAt: "2024-02-24T23:32:00Z",
+      expected: true
+    },
+  ].forEach(({name, scheduledAt, expected}) => {
+    it(name, () => {
+      const input = {
+        scheduledAt: scheduledAt,
+        shop: {
+          timezoneOffsetMinutes: -300
+        }
+      };
+
+      const expectedOutput = {
+        isWeekend: expected,
+      };
+
+      const result = main(input);
+      expect(result).toEqual(expectedOutput);
+    });
+  });
+});


### PR DESCRIPTION
This adds an example code action that returns a boolean based on whether the `scheduledAt` time is a weekend for the shop or not.

This is useful for running business processes on business days.