### PR TITLE
Count metafield example

### DIFF
--- a/run-code-examples/count-orders-with-company-metafield/index.js
+++ b/run-code-examples/count-orders-with-company-metafield/index.js
@@ -1,0 +1,38 @@
+/**
+ * Totals the sales for a salesperson's previous orders, using metafields to get the salesperson's name
+*/
+
+function getSalesperson(order) {
+  return order?.purchasingEntity?.PurchasingCompany?.company?.primarySalesperson?.value;
+}
+
+export default function main(input) {
+  const orders = input.getOrderData || [];
+  const salesperson = getSalesperson(input.order);
+
+  console.log(salesperson);
+
+  let total = 0;
+
+  if (salesperson !== undefined) {
+    //Loop through orders using forEach
+    orders.forEach((order) => {
+      // Add null checks for all potentially undefined properties
+      const amount = order?.currentTotalPriceSet?.shopMoney?.amount;
+      const orderSalesperson = getSalesperson(order);
+
+      console.log(orderSalesperson);
+
+      if (amount > 0 && amount != null && orderSalesperson != undefined) {
+        if (orderSalesperson === salesperson) {
+          total += amount;
+          console.log(total);
+        }
+      }
+    });
+  }
+
+  return {
+    totalSales: total,
+  };
+}

--- a/run-code-examples/count-orders-with-company-metafield/input.graphql
+++ b/run-code-examples/count-orders-with-company-metafield/input.graphql
@@ -1,0 +1,33 @@
+query {
+  order {
+    purchasingEntity {
+      ... on PurchasingCompany {
+        company {
+          primarySalesperson {
+            value
+          }
+        }
+      }
+    }
+  }
+  getOrderData {
+    id
+    currentTotalPriceSet {
+      shopMoney {
+        amount
+      }
+    }
+    purchasingEntity {
+      ... on PurchasingCompany {
+        company {
+          primarySalesperson {
+            value
+          }
+          primarySalespersonName {
+            value
+          }
+        }
+      }
+    }
+  }
+}

--- a/run-code-examples/count-orders-with-company-metafield/output.graphql
+++ b/run-code-examples/count-orders-with-company-metafield/output.graphql
@@ -1,0 +1,5 @@
+"Output object"
+type Output {
+  "Total sales amount for the salesperson"
+  totalSales: Float!
+}

--- a/run-code-examples/count-orders-with-company-metafield/tests/salesperson.test.js
+++ b/run-code-examples/count-orders-with-company-metafield/tests/salesperson.test.js
@@ -1,0 +1,246 @@
+import main from "../index";
+
+describe("Salesperson Total Sales Calculator", () => {
+  it("calculates total sales for a salesperson with multiple orders", () => {
+    const input = {
+      order: {
+        purchasingEntity: {
+          PurchasingCompany: {
+            company: {
+              primarySalesperson: {
+                value: "John Doe"
+              }
+            }
+          }
+        }
+      },
+      getOrderData: [
+        {
+          currentTotalPriceSet: {
+            shopMoney: {
+              amount: 100
+            }
+          },
+          purchasingEntity: {
+            PurchasingCompany: {
+              company: {
+                primarySalesperson: {
+                  value: "John Doe"
+                }
+              }
+            }
+          }
+        },
+        {
+          currentTotalPriceSet: {
+            shopMoney: {
+              amount: 200
+            }
+          },
+          purchasingEntity: {
+            PurchasingCompany: {
+              company: {
+                primarySalesperson: {
+                  value: "John Doe"
+                }
+              }
+            }
+          }
+        },
+        {
+          currentTotalPriceSet: {
+            shopMoney: {
+              amount: 300
+            }
+          },
+          purchasingEntity: {
+            PurchasingCompany: {
+              company: {
+                primarySalesperson: {
+                  value: "Jane Smith" // Different salesperson
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const expectedOutput = {
+      totalSales: 300 // 100 + 200, excluding the 300 from Jane Smith
+    };
+
+    const result = main(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("returns zero total when no orders match the salesperson", () => {
+    const input = {
+      order: {
+        purchasingEntity: {
+          PurchasingCompany: {
+            company: {
+              primarySalesperson: {
+                value: "John Doe"
+              }
+            }
+          }
+        }
+      },
+      getOrderData: [
+        {
+          currentTotalPriceSet: {
+            shopMoney: {
+              amount: 100
+            }
+          },
+          purchasingEntity: {
+            PurchasingCompany: {
+              company: {
+                primarySalesperson: {
+                  value: "Jane Smith"
+                }
+              }
+            }
+          }
+        },
+        {
+          currentTotalPriceSet: {
+            shopMoney: {
+              amount: 200
+            }
+          },
+          purchasingEntity: {
+            PurchasingCompany: {
+              company: {
+                primarySalesperson: {
+                  value: "Bob Johnson"
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const expectedOutput = {
+      totalSales: 0
+    };
+
+    const result = main(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("handles orders with missing or invalid data", () => {
+    const input = {
+      order: {
+        purchasingEntity: {
+          PurchasingCompany: {
+            company: {
+              primarySalesperson: {
+                value: "John Doe"
+              }
+            }
+          }
+        }
+      },
+      getOrderData: [
+        {
+          currentTotalPriceSet: {
+            shopMoney: {
+              amount: 100
+            }
+          },
+          purchasingEntity: {
+            PurchasingCompany: {
+              company: {
+                primarySalesperson: {
+                  value: "John Doe"
+                }
+              }
+            }
+          }
+        },
+        {
+          currentTotalPriceSet: {
+            shopMoney: {
+              amount: 0 // Zero amount should be ignored
+            }
+          },
+          purchasingEntity: {
+            PurchasingCompany: {
+              company: {
+                primarySalesperson: {
+                  value: "John Doe"
+                }
+              }
+            }
+          }
+        },
+        {
+          currentTotalPriceSet: {
+            shopMoney: {
+              amount: 200
+            }
+          },
+          // Missing purchasingEntity data
+        },
+        {
+          // Missing amount data
+          purchasingEntity: {
+            PurchasingCompany: {
+              company: {
+                primarySalesperson: {
+                  value: "John Doe"
+                }
+              }
+            }
+          }
+        },
+        {
+          purchasingEntity: null // Missing purchasingEntity data
+        }
+      ]
+    };
+
+    const expectedOutput = {
+      totalSales: 100 // Only the first order should count
+    };
+
+    const result = main(input);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("returns zero when salesperson is undefined", () => {
+    const input = {
+      order: {
+        // Missing salesperson data
+      },
+      getOrderData: [
+        {
+          currentTotalPriceSet: {
+            shopMoney: {
+              amount: 100
+            }
+          },
+          purchasingEntity: {
+            PurchasingCompany: {
+              company: {
+                primarySalesperson: {
+                  value: "John Doe"
+                }
+              }
+            }
+          }
+        }
+      ]
+    };
+
+    const expectedOutput = {
+      totalSales: 0
+    };
+
+    const result = main(input);
+    expect(result).toEqual(expectedOutput);
+  });
+});

--- a/run-code-examples/filter-fulfillment-order-line-items/index.js
+++ b/run-code-examples/filter-fulfillment-order-line-items/index.js
@@ -1,0 +1,33 @@
+// Filter line items based on merchants desired parameter
+function shouldSplitLineItem(orderLineItems, fulfillmentOrderLineItem) {
+   return orderLineItems.some(lineItem => {
+    return lineItem.variant.product.title === fulfillmentOrderLineItem.productTitle && lineItem.variant.product.tags.includes("Refrigerated");
+  });
+}
+
+export default function main(input) {
+  const fulfillmentOrder = input.fulfillmentOrder
+  const orderLineItems = input.fulfillmentOrder.order.lineItems
+  const fulfillmentOrderSplitLineItems = []
+  const fulfillmentOrderSplits = []
+
+  fulfillmentOrder.lineItems.forEach(fulfillmentOrderLineItem => {
+    if (shouldSplitLineItem(orderLineItems, fulfillmentOrderLineItem)) {
+      fulfillmentOrderSplitLineItems.push({
+        "id": fulfillmentOrderLineItem.id,
+        "quantity": fulfillmentOrderLineItem.totalQuantity
+      })
+    }
+  });
+
+  if (fulfillmentOrderSplitLineItems.length >= 0) {
+    fulfillmentOrderSplits.push({
+      "fulfillmentOrderId": fulfillmentOrder.id,
+      "fulfillmentOrderLineItems": fulfillmentOrderSplitLineItems,
+    })
+  }
+
+  return {
+    fulfillmentOrderSplits: JSON.stringify(fulfillmentOrderSplits, null),
+  }
+}

--- a/run-code-examples/filter-fulfillment-order-line-items/input.graphql
+++ b/run-code-examples/filter-fulfillment-order-line-items/input.graphql
@@ -1,0 +1,20 @@
+query{
+  fulfillmentOrder {
+    id
+    lineItems {
+      id
+      totalQuantity
+      productTitle
+    }
+    order{
+      lineItems {
+        variant {
+          product {
+            title
+            tags
+          }
+        }
+      }
+    }
+  }
+}

--- a/run-code-examples/filter-fulfillment-order-line-items/output.graphql
+++ b/run-code-examples/filter-fulfillment-order-line-items/output.graphql
@@ -1,0 +1,4 @@
+type Output {
+  "The filtered fulfillment order line items"
+  fulfillmentOrderSplits: String!
+}

--- a/run-code-examples/filter-fulfillment-order-line-items/tests/example.test.js
+++ b/run-code-examples/filter-fulfillment-order-line-items/tests/example.test.js
@@ -1,0 +1,54 @@
+import main from "../index";
+
+describe("main", () => {
+  it("filters fulfillment order line items based on product tags", () => {
+    const input = {
+      fulfillmentOrder: {
+        id: "gid://shopify/FulfillmentOrder/1",
+        lineItems: [
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/1",
+            "totalQuantity": 1,
+            "productTitle": "Dry Product"
+          },
+          {
+            "id": "gid://shopify/FulfillmentOrderLineItem/2",
+            "totalQuantity": 1,
+            "productTitle": "Refrigerated Product"
+          }
+        ],
+        order: {
+          lineItems: [
+          {
+            "variant": {
+              "product": {
+                "title": "Dry Product",
+                "tags": [
+                  "Dry"
+                ]
+              }
+            }
+          },
+          {
+            "variant": {
+              "product": {
+                "title": "Refrigerated Product",
+                "tags": [
+                  "Refrigerated"
+                ]
+              }
+            }
+          }
+          ]
+        }
+      }
+    };
+
+    const expectedOutput = {
+      fulfillmentOrderSplits: "[{\"fulfillmentOrderId\":\"gid://shopify/FulfillmentOrder/1\",\"fulfillmentOrderLineItems\":[{\"id\":\"gid://shopify/FulfillmentOrderLineItem/2\",\"quantity\":1}]}]",
+    };
+
+    const result = main(input);
+    expect(result).toEqual(expectedOutput);
+  });
+});


### PR DESCRIPTION
Adding another example that shows how to count items from "Get order data" and use metafields. 

Also adds another example from Jacoby that we reviewed awhile back but forgot to deploy. 