### PR TITLE
Add chat completions example for LLM API response parsing

### DIFF
--- a/run-code-examples/http-chat-completions/README.md
+++ b/run-code-examples/http-chat-completions/README.md
@@ -31,7 +31,7 @@ In your Shopify Flow workflow:
 
 1. Add a "Send HTTP Request" action before the "Run Code" action
 2. Configure it with one of the example cURL requests below
-3. Store your API key in Flow's environment variables for security
+3. Store your API key in Flow's secret storage for security
 
 ### Step 2: Add Run Code Action
 

--- a/run-code-examples/http-chat-completions/README.md
+++ b/run-code-examples/http-chat-completions/README.md
@@ -159,7 +159,7 @@ The parser handles various error scenarios:
 
 ## Security Best Practices
 
-1. **Never hardcode API keys** - Use Flow's environment variables
+1. **Never hardcode API keys** - Use Flow's secret storage
 2. **Set appropriate rate limits** - Prevent excessive API calls
 3. **Validate responses** - Check the `success` field before using `content`
 4. **Monitor usage** - Track token consumption via the `usage` field

--- a/run-code-examples/http-chat-completions/README.md
+++ b/run-code-examples/http-chat-completions/README.md
@@ -1,0 +1,207 @@
+# HTTP Chat Completions Parser
+
+This example demonstrates how to parse responses from LLM (Large Language Model) chat completion APIs in Shopify Flow using the Run Code action. It handles responses from OpenAI, Anthropic Claude, and Google Gemini APIs.
+
+## Overview
+
+When using Shopify Flow's "Send HTTP Request" action to call an LLM API, the response comes back as a JSON string in the `body` field. This code action parses that response and extracts the relevant information in a structured format.
+
+## Supported Providers
+
+### OpenAI
+- **Documentation**: [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create)
+- **Endpoint**: `https://api.openai.com/v1/chat/completions`
+- **Models**: GPT-4, GPT-3.5-turbo, etc.
+
+### Anthropic Claude
+- **Documentation**: [Anthropic Messages API](https://docs.anthropic.com/en/api/messages)
+- **Endpoint**: `https://api.anthropic.com/v1/messages`
+- **Models**: Claude 3 Opus, Claude 3 Sonnet, Claude 3 Haiku
+
+### Google Gemini (OpenAI-compatible)
+- **Documentation**: [Gemini OpenAI Compatibility](https://ai.google.dev/gemini-api/docs/openai)
+- **Endpoint**: `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`
+- **Models**: Gemini 2.0 Flash, Gemini 1.5 Pro, etc.
+
+## How to Use
+
+### Step 1: Configure Send HTTP Request
+
+In your Shopify Flow workflow:
+
+1. Add a "Send HTTP Request" action before the "Run Code" action
+2. Configure it with one of the example cURL requests below
+3. Store your API key in Flow's environment variables for security
+
+### Step 2: Add Run Code Action
+
+1. Add a "Run Code" action after the Send HTTP Request
+2. Copy the code from `index.js` into the action
+3. Configure the input query to receive the HTTP response
+4. Configure the output schema to match `output.graphql`
+
+## Example cURL Requests
+
+Copy and adapt these examples for the Send HTTP Request action:
+
+### OpenAI Example
+
+```bash
+curl https://api.openai.com/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_OPENAI_API_KEY" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant for an e-commerce store."
+      },
+      {
+        "role": "user",
+        "content": "Write a product description for: {{product.title}}"
+      }
+    ],
+    "temperature": 0.7,
+    "max_tokens": 500
+  }'
+```
+
+> [!NOTE]
+> Replace `YOUR_OPENAI_API_KEY` with your actual OpenAI API key stored in Flow's secret storage. You can also use `gpt-3.5-turbo` or other models as needed.
+
+### Anthropic Claude Example
+
+```bash
+curl https://api.anthropic.com/v1/messages \
+  -H "content-type: application/json" \
+  -H "x-api-key: YOUR_ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-3-sonnet-20240229",
+    "max_tokens": 500,
+    "temperature": 0.7,
+    "system": "You are a helpful assistant for an e-commerce store.",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Write a product description for: {{product.title}}"
+      }
+    ]
+  }'
+```
+
+> [!NOTE]
+> Replace `YOUR_ANTHROPIC_API_KEY` with your actual Anthropic API key stored in Flow's secret storage. You can also use other Claude models like `claude-3-opus` or `claude-3-haiku`.
+
+### Google Gemini Example (OpenAI-compatible)
+
+```bash
+curl https://generativelanguage.googleapis.com/v1beta/openai/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_GEMINI_API_KEY" \
+  -d '{
+    "model": "gemini-2.0-flash",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant for an e-commerce store."
+      },
+      {
+        "role": "user",
+        "content": "Write a product description for: {{product.title}}"
+      }
+    ],
+    "temperature": 0.7,
+    "max_tokens": 500
+  }'
+```
+
+> [!NOTE]
+> Replace `YOUR_GEMINI_API_KEY` with your actual Google Gemini API key stored in Flow's secret storage. You can also use other Gemini models like `gemini-1.5-pro`.
+
+## Flow Variables
+
+In the cURL examples above, you can use Flow variables like:
+- `{{product.title}}` - Product title
+- `{{customer.email}}` - Customer email
+- `{{order.name}}` - Order number
+- Any other data available in your workflow trigger or from upstream actions
+
+## Output Structure
+
+The code returns a structured object with:
+
+```javascript
+{
+  success: Boolean,        // Whether parsing was successful
+  error: String,          // Error message if any
+  content: String,        // The AI's response text
+  model: String,          // Model used (e.g., "gpt-4", "claude-3-sonnet")
+  usage: {                // Token usage statistics
+    promptTokens: Number,
+    completionTokens: Number,
+    totalTokens: Number
+  },
+  finishReason: String,   // Why the response ended (e.g., "stop", "length")
+  provider: String        // "openai-compatible" or "anthropic"
+}
+```
+
+## Error Handling
+
+The parser handles various error scenarios:
+- Invalid JSON responses
+- Missing required fields
+- API error responses
+- Network failures
+- Unknown response formats
+
+## Security Best Practices
+
+1. **Never hardcode API keys** - Use Flow's environment variables
+2. **Set appropriate rate limits** - Prevent excessive API calls
+3. **Validate responses** - Check the `success` field before using `content`
+4. **Monitor usage** - Track token consumption via the `usage` field
+5. **Use appropriate models** - Balance cost vs. quality for your use case
+
+## Common Use Cases
+
+- **Product Description Generation**: Generate SEO-friendly product descriptions
+- **Customer Support Responses**: Draft personalized email responses
+- **Content Translation**: Translate product information or customer messages
+- **Order Summary Generation**: Create natural language order summaries
+- **Review Response Drafting**: Generate responses to customer reviews
+- **FAQ Generation**: Create frequently asked questions from product data
+
+## Troubleshooting
+
+### Issue: "Failed to parse response"
+- Check that the Send HTTP Request is returning valid JSON
+- Verify the API endpoint is correct
+- Ensure your API key has proper permissions
+
+### Issue: "Unknown response format"
+- The API response structure may have changed
+- Check the provider's documentation for updates
+- Review the raw response in `content` when error occurs
+
+### Issue: No response content
+- Verify the API key is valid and active
+- Check API rate limits and quotas
+- Ensure the request body is properly formatted
+
+## Testing
+
+Run the included tests to verify the parser works correctly:
+
+```bash
+npm test -- run-code-examples/http-chat-completions/tests/example.test.js
+```
+
+## Support
+
+For issues or questions about:
+- **This example**: Open an issue in this repository
+- **Shopify Flow**: Visit [Shopify Help Center](https://help.shopify.com/en/manual/shopify-flow)
+- **API Providers**: Consult their respective documentation linked above

--- a/run-code-examples/http-chat-completions/index.js
+++ b/run-code-examples/http-chat-completions/index.js
@@ -1,0 +1,93 @@
+/**
+ * Parse the response from a Send HTTP Request step that calls an LLM chat completions API.
+ * This example handles responses from OpenAI, Anthropic Claude, and Google Gemini APIs.
+ *
+ * The Send HTTP Request step should be configured to call one of these endpoints:
+ * - OpenAI: https://api.openai.com/v1/chat/completions
+ * - Anthropic: https://api.anthropic.com/v1/messages
+ * - Google Gemini: https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
+ */
+export default function main({sendHTTPRequest}) {
+  if (!sendHTTPRequest || !sendHTTPRequest.body) {
+    return {
+      success: false,
+      error: "No HTTP request response found",
+      content: null,
+      model: null,
+      usage: null
+    };
+  }
+
+  try {
+    const response = JSON.parse(sendHTTPRequest.body);
+
+    // Detect and parse OpenAI-style response (used by OpenAI and Gemini)
+    if (response.choices && Array.isArray(response.choices)) {
+      const firstChoice = response.choices[0];
+      return {
+        success: true,
+        error: null,
+        content: firstChoice.message?.content || firstChoice.text || "",
+        model: response.model || null,
+        usage: response.usage ? {
+          promptTokens: response.usage.prompt_tokens,
+          completionTokens: response.usage.completion_tokens,
+          totalTokens: response.usage.total_tokens
+        } : null,
+        finishReason: firstChoice.finish_reason || null,
+        provider: "openai-compatible"
+      };
+    }
+
+    // Detect and parse Anthropic Claude response
+    if (response.content && Array.isArray(response.content)) {
+      const textContent = response.content
+        .filter(block => block.type === "text")
+        .map(block => block.text)
+        .join("\n");
+
+      return {
+        success: true,
+        error: null,
+        content: textContent,
+        model: response.model || null,
+        usage: response.usage ? {
+          promptTokens: response.usage.input_tokens,
+          completionTokens: response.usage.output_tokens,
+          totalTokens: (response.usage.input_tokens || 0) + (response.usage.output_tokens || 0)
+        } : null,
+        finishReason: response.stop_reason || null,
+        provider: "anthropic"
+      };
+    }
+
+    // Handle error responses
+    if (response.error) {
+      return {
+        success: false,
+        error: response.error.message || response.error.type || "Unknown error",
+        content: null,
+        model: null,
+        usage: null
+      };
+    }
+
+    // Unknown response format
+    return {
+      success: false,
+      error: "Unknown response format",
+      content: JSON.stringify(response),
+      model: null,
+      usage: null
+    };
+
+  } catch (parseError) {
+    return {
+      success: false,
+      error: `Failed to parse response: ${parseError.message}`,
+      content: sendHTTPRequest.body,
+      model: null,
+      usage: null
+    };
+  }
+}

--- a/run-code-examples/http-chat-completions/input.graphql
+++ b/run-code-examples/http-chat-completions/input.graphql
@@ -1,0 +1,7 @@
+query SendHTTPRequest {
+  sendHTTPRequest {
+    body
+    status
+    headers
+  }
+}

--- a/run-code-examples/http-chat-completions/output.graphql
+++ b/run-code-examples/http-chat-completions/output.graphql
@@ -1,0 +1,15 @@
+type Output {
+  success: Boolean!
+  error: String
+  content: String
+  model: String
+  usage: UsageInfo
+  finishReason: String
+  provider: String
+}
+
+type UsageInfo {
+  promptTokens: Int
+  completionTokens: Int
+  totalTokens: Int
+}

--- a/run-code-examples/http-chat-completions/tests/example.test.js
+++ b/run-code-examples/http-chat-completions/tests/example.test.js
@@ -1,0 +1,268 @@
+import main from '../index.js';
+
+describe('HTTP Chat Completions Parser', () => {
+  describe('OpenAI-style responses', () => {
+    test('should parse OpenAI chat completion response', () => {
+      const input = {
+        sendHTTPRequest: {
+          body: JSON.stringify({
+            id: "chatcmpl-123",
+            object: "chat.completion",
+            created: 1677652288,
+            model: "gpt-4",
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "Hello! How can I help you today?"
+              },
+              finish_reason: "stop"
+            }],
+            usage: {
+              prompt_tokens: 9,
+              completion_tokens: 12,
+              total_tokens: 21
+            }
+          }),
+          status: 200
+        }
+      };
+
+      const result = main(input);
+      
+      expect(result.success).toBe(true);
+      expect(result.error).toBe(null);
+      expect(result.content).toBe("Hello! How can I help you today?");
+      expect(result.model).toBe("gpt-4");
+      expect(result.usage).toEqual({
+        promptTokens: 9,
+        completionTokens: 12,
+        totalTokens: 21
+      });
+      expect(result.finishReason).toBe("stop");
+      expect(result.provider).toBe("openai-compatible");
+    });
+
+    test('should parse Gemini OpenAI-compatible response', () => {
+      const input = {
+        sendHTTPRequest: {
+          body: JSON.stringify({
+            id: "gemini-123",
+            model: "gemini-2.0-flash",
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "I'm Gemini, how can I assist?"
+              },
+              finish_reason: "stop"
+            }],
+            usage: {
+              prompt_tokens: 10,
+              completion_tokens: 8,
+              total_tokens: 18
+            }
+          }),
+          status: 200
+        }
+      };
+
+      const result = main(input);
+      
+      expect(result.success).toBe(true);
+      expect(result.content).toBe("I'm Gemini, how can I assist?");
+      expect(result.model).toBe("gemini-2.0-flash");
+      expect(result.provider).toBe("openai-compatible");
+    });
+  });
+
+  describe('Anthropic Claude responses', () => {
+    test('should parse Anthropic Claude response', () => {
+      const input = {
+        sendHTTPRequest: {
+          body: JSON.stringify({
+            id: "msg_123",
+            type: "message",
+            role: "assistant",
+            model: "claude-sonnet-4-20250514",
+            content: [{
+              type: "text",
+              text: "Hello! I'm Claude. How can I help you?"
+            }],
+            stop_reason: "end_turn",
+            stop_sequence: null,
+            usage: {
+              input_tokens: 10,
+              output_tokens: 15
+            }
+          }),
+          status: 200
+        }
+      };
+
+      const result = main(input);
+      
+      expect(result.success).toBe(true);
+      expect(result.error).toBe(null);
+      expect(result.content).toBe("Hello! I'm Claude. How can I help you?");
+      expect(result.model).toBe("claude-sonnet-4-20250514");
+      expect(result.usage).toEqual({
+        promptTokens: 10,
+        completionTokens: 15,
+        totalTokens: 25
+      });
+      expect(result.finishReason).toBe("end_turn");
+      expect(result.provider).toBe("anthropic");
+    });
+
+    test('should handle multiple text blocks in Anthropic response', () => {
+      const input = {
+        sendHTTPRequest: {
+          body: JSON.stringify({
+            id: "msg_456",
+            type: "message",
+            role: "assistant",
+            model: "claude-3-opus",
+            content: [
+              { type: "text", text: "First paragraph." },
+              { type: "text", text: "Second paragraph." }
+            ],
+            stop_reason: "stop_sequence",
+            usage: {
+              input_tokens: 20,
+              output_tokens: 30
+            }
+          }),
+          status: 200
+        }
+      };
+
+      const result = main(input);
+      
+      expect(result.success).toBe(true);
+      expect(result.content).toBe("First paragraph.\nSecond paragraph.");
+      expect(result.provider).toBe("anthropic");
+    });
+  });
+
+  describe('Error handling', () => {
+    test('should handle missing sendHTTPRequest', () => {
+      const result = main({});
+      
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("No HTTP request response found");
+      expect(result.content).toBe(null);
+    });
+
+    test('should handle missing body', () => {
+      const input = {
+        sendHTTPRequest: {
+          status: 200
+        }
+      };
+      
+      const result = main(input);
+      
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("No HTTP request response found");
+    });
+
+    test('should handle invalid JSON', () => {
+      const input = {
+        sendHTTPRequest: {
+          body: "Invalid JSON {",
+          status: 200
+        }
+      };
+      
+      const result = main(input);
+      
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to parse response");
+      expect(result.content).toBe("Invalid JSON {");
+    });
+
+    test('should handle API error response', () => {
+      const input = {
+        sendHTTPRequest: {
+          body: JSON.stringify({
+            error: {
+              message: "Invalid API key",
+              type: "authentication_error",
+              code: "invalid_api_key"
+            }
+          }),
+          status: 401
+        }
+      };
+      
+      const result = main(input);
+      
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Invalid API key");
+      expect(result.content).toBe(null);
+    });
+
+    test('should handle unknown response format', () => {
+      const input = {
+        sendHTTPRequest: {
+          body: JSON.stringify({
+            unknownField: "value",
+            anotherField: 123
+          }),
+          status: 200
+        }
+      };
+      
+      const result = main(input);
+      
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Unknown response format");
+      expect(result.content).toContain("unknownField");
+    });
+  });
+
+  describe('Edge cases', () => {
+    test('should handle response without usage data', () => {
+      const input = {
+        sendHTTPRequest: {
+          body: JSON.stringify({
+            choices: [{
+              message: {
+                content: "Response without usage"
+              }
+            }]
+          }),
+          status: 200
+        }
+      };
+      
+      const result = main(input);
+      
+      expect(result.success).toBe(true);
+      expect(result.content).toBe("Response without usage");
+      expect(result.usage).toBe(null);
+    });
+
+    test('should handle response without model information', () => {
+      const input = {
+        sendHTTPRequest: {
+          body: JSON.stringify({
+            choices: [{
+              message: {
+                content: "Response without model"
+              }
+            }]
+          }),
+          status: 200
+        }
+      };
+      
+      const result = main(input);
+      
+      expect(result.success).toBe(true);
+      expect(result.content).toBe("Response without model");
+      expect(result.model).toBe(null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added a new Run Code example that parses responses from LLM chat completion APIs
- Supports OpenAI, Anthropic Claude, and Google Gemini APIs
- Provides robust error handling and comprehensive test coverage

## What this PR does
This PR adds a new example to the Flow Code Examples repository that demonstrates how to parse responses from Large Language Model (LLM) APIs when using Shopify Flow's "Send HTTP Request" action.

### Features
- ✅ Parses OpenAI-compatible responses (OpenAI GPT, Google Gemini)
- ✅ Parses Anthropic Claude responses
- ✅ Extracts content, model info, usage statistics, and finish reasons
- ✅ Comprehensive error handling for invalid JSON, API errors, and unknown formats
- ✅ 11 test cases covering all major scenarios
- ✅ Detailed README with provider documentation links and cURL examples

## Testing
All tests pass successfully:
- 11 test cases covering OpenAI, Anthropic, and error scenarios
- Tests handle edge cases like missing usage data and unknown response formats
- Ran full test suite to ensure no regressions

## Documentation
The README includes:
- Links to official API documentation for each provider
- Ready-to-use cURL examples that can be copied into Flow's Send HTTP Request step
- Security best practices for API key management
- Common e-commerce use cases
- Troubleshooting guide

## Related Issue
Closes [Add chat completions example to flow-code-examples](https://github.com/shop/issues-automate/issues/608)

🤖 Generated with [Claude Code](https://claude.ai/code)